### PR TITLE
encode URLs so that (for example) spaces get handled

### DIFF
--- a/gitlab.coffee
+++ b/gitlab.coffee
@@ -80,9 +80,9 @@ module.exports = (robot) ->
           branch = hook.ref.split("/")[2..].join("/")
           # if the ref before the commit is 00000, this is a new branch
           if /^0+$/.test(hook.before)
-            message = "#{bold(hook.user_name)} pushed a new branch (#{bold(branch)}) to #{bold(hook.repository.name)} #{underline(hook.repository.homepage)}"
+            message = "#{bold(hook.user_name)} pushed a new branch (#{bold(branch)}) to #{bold(hook.repository.name)} #{underline(encodeURI(hook.repository.homepage))}"
           else
-            message = "#{bold(hook.user_name)} pushed to #{branch} at #{hook.repository.name} #{underline(hook.repository.homepage + '/compare/' + hook.before.substr(0,9) + '...' + hook.after.substr(0,9))}"
+            message = "#{bold(hook.user_name)} pushed to #{branch} at #{hook.repository.name} #{underline(encodeURI(hook.repository.homepage + '/compare/' + hook.before.substr(0,9) + '...' + hook.after.substr(0,9)))}"
             message += "\n" + hook.commits.map((commit) -> commit.message.split("\n")[0]).join("\n")
           robot.send user, message
         # not code? must be a something good!


### PR DESCRIPTION
Encodes the project URL so that if it contains non-URL characters, they
still work as a link when the bot speaks into channel
